### PR TITLE
Fixed import with workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/actuation_computer.cpython-38.pyc
+__pycache__/calibration_postprocessing.cpython-38.pyc
+__pycache__/init_constants.cpython-38.pyc

--- a/actuation_computer.py
+++ b/actuation_computer.py
@@ -1,9 +1,14 @@
-from init_constants import plotFileField
-from calibration_postprocessing import kernelAveraging
+try:
+    from .init_constants import plotFileField
+    from .calibration_postprocessing import kernelAveraging
+    from .init_constants import plotField
+except ImportError:
+    from init_constants import plotFileField
+    from calibration_postprocessing import kernelAveraging
+    from init_constants import plotField
 import numpy as np
 from numpy.linalg import pinv,norm
 import matplotlib.pyplot as plt
-from init_constants import plotField
 
 #kernel averaging
 smoothingField=False


### PR DESCRIPTION
Added a workaround to be able to import the magnetic computer class from outside the "package"